### PR TITLE
fix for unable to deactivate effects

### DIFF
--- a/extensions/ConstitutionalAmendments/source/extension.xml
+++ b/extensions/ConstitutionalAmendments/source/extension.xml
@@ -22,6 +22,8 @@
 		<script name="PowerManager2" file="scripts/manager_power2.lua"/>
 		<script name="ActionDamage2" file="scripts/manager_action_damage2.lua"/>
 		<script name="ActionHeal2" file="scripts/manager_action_heal2.lua"/>
+		<script name="EffectManager5ECA" file="scripts/manager_effect_5E_CA.lua"/>
+		<script name="ActorManager2CA" file="scripts/manager_actor2_CA.lua"/>
 
 		<!-- updates the character sheet to add support for max PC HP adjustments as well as toggling between wounds and current HP -->
 		<includefile source="campaign/record_char_main.xml" />

--- a/extensions/ConstitutionalAmendments/source/scripts/manager_actor2_CA.lua
+++ b/extensions/ConstitutionalAmendments/source/scripts/manager_actor2_CA.lua
@@ -1,0 +1,744 @@
+-- 
+-- Please see the license.html file included with this distribution for 
+-- attribution and copyright information.
+--
+
+function getPercentWounded(rActor)
+	local sActorType, nodeActor = ActorManager.getTypeAndNode(rActor);
+
+	if sActorType == "pc" then
+		return getPercentWounded2("pc", nodeActor);
+	elseif sActorType == "ct" then
+		return getPercentWounded2("ct", nodeActor);
+	end
+	
+	return 0, "";
+end
+
+function getPercentWounded2(sNodeType, node)
+	local nHP, nWounds, nDeathSaveFail;
+	if sNodeType == "pc" then
+		nHP = math.max(DB.getValue(node, "hp.total", 0), 0);
+		nWounds = math.max(DB.getValue(node, "hp.wounds", 0), 0);
+		nDeathSaveFail = DB.getValue(node, "hp.deathsavefail", 0);
+	elseif sNodeType == "ct" then
+		nHP = math.max(DB.getValue(node, "hptotal", 0), 0);
+		nWounds = math.max(DB.getValue(node, "wounds", 0), 0);
+		nDeathSaveFail = DB.getValue(node, "deathsavefail", 0);
+	end
+	
+	local nPercentWounded = 0;
+	if nHP > 0 then
+		nPercentWounded = nWounds / nHP;
+	end
+	
+	local sStatus;
+	if nPercentWounded >= 1 then
+		if nDeathSaveFail >= 3 then
+			sStatus = "Dead";
+		else
+			local rActor;
+			if sNodeType == "pc" then
+				rActor = ActorManager.getActor("pc", node);
+			elseif sNodeType == "ct" then
+				rActor = ActorManager.getActor("ct", node);
+			end
+			if EffectManager5E.hasEffect(rActor, "Stable") then
+				sStatus = "Unconscious";
+			else
+				sStatus = "Dying";
+			end
+			if nDeathSaveFail > 0 then
+				sStatus = sStatus .. " (" .. nDeathSaveFail .. ")";
+			end
+		end
+	elseif OptionsManager.isOption("WNDC", "detailed") then
+		if nPercentWounded >= .75 then
+			sStatus = "Critical";
+		elseif nPercentWounded >= .5 then
+			sStatus = "Heavy";
+		elseif nPercentWounded >= .25 then
+			sStatus = "Moderate";
+		elseif nPercentWounded > 0 then
+			sStatus = "Light";
+		else
+			sStatus = "Healthy";
+		end
+	else
+		if nPercentWounded >= .5 then
+			sStatus = "Heavy";
+		elseif nPercentWounded > 0 then
+			sStatus = "Wounded";
+		else
+			sStatus = "Healthy";
+		end
+	end
+	
+	return nPercentWounded, sStatus;
+end
+
+-- Based on the percent wounded, change the font color for the Wounds field
+function getWoundColor(sNodeType, node)
+	local nPercentWounded, sStatus = getPercentWounded2(sNodeType, node);
+	
+	local sColor = ColorManager.getHealthColor(nPercentWounded, false);
+
+	return sColor, nPercentWounded, sStatus;
+end
+
+-- Based on the percent wounded, change the token health bar color
+function getWoundBarColor(sNodeType, node)
+	local nPercentWounded, sStatus = getPercentWounded2(sNodeType, node);
+	
+	local sColor = ColorManager.getTokenHealthColor(nPercentWounded, true);
+
+	return sColor, nPercentWounded, sStatus;
+end
+
+function getAbilityEffectsBonus(rActor, sAbility)
+	if not rActor or not sAbility then
+		return 0, 0;
+	end
+	
+	local sAbilityEffect = DataCommon.ability_ltos[sAbility];
+	if not sAbilityEffect then
+		return 0, 0;
+	end
+	
+	-- this is modified to not re-enable skipped effects	
+	local nAbilityMod, nAbilityEffects = EffectManager5ECA.getEffectsBonus(rActor, sAbilityEffect, true);
+	
+	local nAbilityScore = getAbilityScore(rActor, sAbility);
+	if nAbilityScore > 0 then
+		local nAffectedScore = math.max(nAbilityScore + nAbilityMod, 0);
+		
+		local nCurrentBonus = math.floor((nAbilityScore - 10) / 2);
+		local nAffectedBonus = math.floor((nAffectedScore - 10) / 2);
+		
+		nAbilityMod = nAffectedBonus - nCurrentBonus;
+	else
+		if nAbilityMod > 0 then
+			nAbilityMod = math.floor(nAbilityMod / 2);
+		else
+			nAbilityMod = math.ceil(nAbilityMod / 2);
+		end
+	end
+
+	return nAbilityMod, nAbilityEffects;
+end
+
+function getClassLevel(nodeActor, sValue)
+	local sClassName = DataCommon.class_valuetoname[sValue];
+	if not sClassName then
+		return 0;
+	end
+	sClassName = sClassName:lower();
+	
+	for _, vNode in pairs(DB.getChildren(nodeActor, "classes")) do
+		if DB.getValue(vNode, "name", ""):lower() == sClassName then
+			return DB.getValue(vNode, "level", 0);
+		end
+	end
+	
+	return 0;
+end
+
+function getAbilityScore(rActor, sAbility)
+	if not sAbility then
+		return -1;
+	end
+	local sActorType, nodeActor = ActorManager.getTypeAndNode(rActor);
+	if not nodeActor then
+		return -1;
+	end
+	
+	local nStatScore = -1;
+	
+	local sShort = string.sub(string.lower(sAbility), 1, 3);
+	if sShort == "lev" then
+		if sActorType == "pc" then
+			nStatScore = DB.getValue(nodeActor, "level", 0);
+		else
+			local sHD = StringManager.trim(DB.getValue(nodeActor, "hd", ""));
+			nStatScore = 0;
+			for sLevelSub in sHD:gmatch("(%d+)[dD](%d+)") do
+				nStatScore = nStatScore + (tonumber(sLevelSub) or 0);
+			end
+		end
+	elseif sShort == "prf" then
+		if sActorType == "pc" then
+			nStatScore = DB.getValue(nodeActor, "profbonus", 0);
+		else
+			local nCR = tonumber(DB.getValue(nodeActor, "cr", ""):match("^%d+$")) or 0;
+			nStatScore = math.max(2, math.floor((nCR - 1) / 4) + 2);
+		end
+	elseif sShort == "str" then
+		nStatScore = DB.getValue(nodeActor, "abilities.strength.score", 0);
+	elseif sShort == "dex" then
+		nStatScore = DB.getValue(nodeActor, "abilities.dexterity.score", 0);
+	elseif sShort == "con" then
+		nStatScore = DB.getValue(nodeActor, "abilities.constitution.score", 0);
+	elseif sShort == "int" then
+		nStatScore = DB.getValue(nodeActor, "abilities.intelligence.score", 0);
+	elseif sShort == "wis" then
+		nStatScore = DB.getValue(nodeActor, "abilities.wisdom.score", 0);
+	elseif sShort == "cha" then
+		nStatScore = DB.getValue(nodeActor, "abilities.charisma.score", 0);
+	elseif StringManager.contains(DataCommon.classes, sAbility) then
+		nStatScore = getClassLevel(nodeActor, sAbility);
+	end
+	
+	return nStatScore;
+end
+
+function getAbilityBonus(rActor, sAbility)
+	if not sAbility then
+		return 0;
+	end
+	local sActorType, nodeActor = ActorManager.getTypeAndNode(rActor);
+	if not nodeActor then
+		return 0;
+	end
+	
+	local nStatScore = getAbilityScore(rActor, sAbility);
+	if nStatScore < 0 then
+		return 0;
+	end
+	
+	local nStatVal = 0;
+	if StringManager.contains(DataCommon.abilities, sAbility) then
+		nStatVal = math.floor((nStatScore - 10) / 2);
+	else
+		nStatVal = nStatScore;
+	end
+	
+	return nStatVal;
+end
+
+function getSave(rActor, sSave)
+	local bADV = false;
+	local bDIS = false;
+	local nValue = getAbilityBonus(rActor, sSave);
+	local aAddText = {};
+	
+	local sActorType, nodeActor = ActorManager.getTypeAndNode(rActor);
+	if sActorType == "pc" then
+		nValue = nValue + DB.getValue(nodeActor, "abilities." .. sSave .. ".savemodifier", 0);
+
+		-- Check for saving throw proficiency
+		if DB.getValue(nodeActor, "abilities." .. sSave .. ".saveprof", 0) == 1 then
+			nValue = nValue + DB.getValue(nodeActor, "profbonus", 0);
+		end
+
+		-- Check for armor non-proficiency
+		if StringManager.contains({"strength", "dexterity"}, sSave) then
+			if DB.getValue(nodeActor, "defenses.ac.prof", 1) == 0 then
+				table.insert(aAddText, Interface.getString("roll_msg_armor_nonprof"));
+				bDIS = true;
+			end
+		end
+	else
+		local sSaves = DB.getValue(nodeActor, "savingthrows", "");
+		for _,v in ipairs(StringManager.split(sSaves, ",;\r", true)) do
+			local sAbility, sSign, sMod = string.match(v, "(%w+)%s*([%+%-–]?)(%d+)");
+			if sAbility then
+				if DataCommon.ability_stol[sAbility:upper()] then
+					sAbility = DataCommon.ability_stol[sAbility:upper()];
+				elseif DataCommon.ability_ltos[sAbility:lower()] then
+					sAbility = sAbility:lower();
+				else
+					sAbility = nil;
+				end
+				
+				if sAbility == sSave then
+					nValue = tonumber(sMod) or 0;
+					if sSign == "-" or sSign == "–" then
+						nValue = 0 - nValue;
+					end
+					break;
+				end
+			end
+		end
+	end
+	
+	return nValue, bADV, bDIS, table.concat(aAddText, " ");
+end
+
+function getCheck(rActor, sCheck, sSkill)
+	local bADV = false;
+	local bDIS = false;
+	local nValue = getAbilityBonus(rActor, sCheck);
+	local aAddText = {};
+
+	local sActorType, nodeActor = ActorManager.getTypeAndNode(rActor);
+	if sActorType == "pc" then
+		nValue = nValue + DB.getValue(nodeActor, "abilities." .. sCheck .. ".checkmodifier", 0);
+
+		-- Check for armor non-proficiency
+		if StringManager.contains({"strength", "dexterity"}, sCheck) then
+			if DB.getValue(nodeActor, "defenses.ac.prof", 1) == 0 then
+				table.insert(aAddText, Interface.getString("roll_msg_armor_nonprof"));
+				bDIS = true;
+			end
+		end
+		
+		-- Check for armor stealth disadvantage
+		if sSkill and sSkill:lower() == Interface.getString("skill_value_stealth"):lower() then
+			if DB.getValue(nodeActor, "defenses.ac.disstealth", 0) == 1 then
+				table.insert(aAddText, Interface.getString("roll_msg_armor_disstealth"));
+				bDIS = true;
+			end
+		end
+	end
+	
+	return nValue, bADV, bDIS, table.concat(aAddText, " ");
+end
+
+function getDefenseAdvantage(rAttacker, rDefender, aAttackFilter)
+	if not rDefender then
+		return false, false;
+	end
+	
+	-- Check effects
+	local bADV = false;
+	local bDIS = false;
+	local bProne = false;
+	
+	if ActorManager.hasCT(rDefender) then
+		if EffectManager5E.hasEffect(rAttacker, "ADVATK", rDefender, true) then
+			bADV = true;
+		elseif #(EffectManager5E.getEffectsByType(rAttacker, "ADVATK", aAttackFilter, rDefender, true)) > 0 then
+			bADV = true;
+		end
+		if EffectManager5E.hasEffect(rAttacker, "DISATK", rDefender, true) then
+			bDIS = true;
+		elseif #(EffectManager5E.getEffectsByType(rAttacker, "DISATK", aAttackFilter, rDefender, true)) > 0 then
+			bDIS = true;
+		end
+		if EffectManager5E.hasEffect(rAttacker, "Invisible", rDefender, true) then
+			bADV = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "GRANTADVATK", rAttacker) then
+			bADV = true;
+		elseif #(EffectManager5E.getEffectsByType(rDefender, "GRANTADVATK", aAttackFilter, rAttacker)) > 0 then
+			bADV = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "GRANTDISATK", rAttacker) then
+			bDIS = true;
+		elseif #(EffectManager5E.getEffectsByType(rDefender, "GRANTDISATK", aAttackFilter, rAttacker)) > 0 then
+			bDIS = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "Blinded", rAttacker) then
+			bADV = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "Invisible", rAttacker) then
+			bDIS = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "Paralyzed", rAttacker) then
+			bADV = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "Prone", rAttacker) then
+			bProne = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "Restrained", rAttacker) then
+			bADV = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "Stunned", rAttacker) then
+			bADV = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "Unconscious", rAttacker) then
+			bADV = true;
+			bProne = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "Dodge", rAttacker) and 
+				not (EffectManager5E.hasEffect(rDefender, "Paralyzed", rAttacker) or
+				EffectManager5E.hasEffect(rDefender, "Stunned", rAttacker) or
+				EffectManager5E.hasEffect(rDefender, "Incapacitated", rAttacker) or
+				EffectManager5E.hasEffect(rDefender, "Unconscious", rAttacker) or
+				EffectManager5E.hasEffect(rDefender, "Grappled", rAttacker) or
+				EffectManager5E.hasEffect(rDefender, "Restrained", rAttacker)) then
+			bDIS = true;
+		end
+		
+		if bProne then
+			if StringManager.contains(aAttackFilter, "melee") then
+				bADV = true;
+			elseif StringManager.contains(aAttackFilter, "ranged") then
+				bDIS = true;
+			end
+		end
+	end
+	-- if bProne then
+		-- local nodeAttacker = ActorManager.getCTNode(rAttacker);
+		-- local nodeDefender = ActorManager.getCTNode(rDefender);
+		-- if nodeAttacker and nodeDefender then
+			-- local tokenAttacker = CombatManager.getTokenFromCT(nodeAttacker);
+			-- local tokenDefender = CombatManager.getTokenFromCT(nodeDefender);
+			-- if tokenAttacker and tokenDefender then
+				-- local nodeAttackerContainer = tokenAttacker.getContainerNode();
+				-- local nodeDefenderContainer = tokenDefender.getContainerNode();
+				-- if nodeAttackerContainer.getNodeName() == nodeDefenderContainer.getNodeName() then
+					-- local nDU = GameSystem.getDistanceUnitsPerGrid();
+					-- local nAttackerSpace = math.ceil(DB.getValue(nodeAttacker, "space", nDU) / nDU);
+					-- local nDefenderSpace = math.ceil(DB.getValue(nodeDefender, "space", nDU) / nDU);
+					-- local xAttacker, yAttacker = tokenAttacker.getPosition();
+					-- local xDefender, yDefender = tokenDefender.getPosition();
+					-- local nGrid = nodeAttackerContainer.getGridSize();
+					
+					-- local xDiff = math.abs(xAttacker - xDefender);
+					-- local yDiff = math.abs(yAttacker - yDefender);
+					-- local gx = math.floor(xDiff / nGrid);
+					-- local gy = math.floor(yDiff / nGrid);
+					
+					-- local nSquares = 0;
+					-- local nStraights = 0;
+					-- if gx > gy then
+						-- nSquares = nSquares + gy;
+						-- nSquares = nSquares + gx - gy;
+					-- else
+						-- nSquares = nSquares + gx;
+						-- nSquares = nSquares + gy - gx;
+					-- end
+					-- nSquares = nSquares - (nAttackerSpace / 2);
+					-- nSquares = nSquares - (nDefenderSpace / 2);
+					-- -- DEBUG - FINISH - Need to be able to get grid type and grid size from token container node
+				-- end
+			-- end
+		-- end
+	-- end
+
+	return bADV, bDIS;
+end
+
+function getDefenseValue(rAttacker, rDefender, rRoll)
+	if not rDefender or not rRoll then
+		return nil, 0, 0, false, false;
+	end
+	
+	-- Base calculations
+	local sAttack = rRoll.sDesc;
+	
+	local sAttackType = string.match(sAttack, "%[ATTACK.*%((%w+)%)%]");
+	local bOpportunity = string.match(sAttack, "%[OPPORTUNITY%]");
+	local nCover = tonumber(string.match(sAttack, "%[COVER %-(%d)%]")) or 0;
+
+	local nDefense = 10;
+	local sDefenseStat = "dexterity";
+
+	local sDefenderType, nodeDefender = ActorManager.getTypeAndNode(rDefender);
+	if not nodeDefender then
+		return nil, 0, 0, false, false;
+	end
+
+	if sDefenderType == "pc" then
+		nDefense = DB.getValue(nodeDefender, "defenses.ac.total", 10);
+		sDefenseStat = DB.getValue(nodeDefender, "ac.sources.ability", "");
+		if sDefenseStat == "" then
+			sDefenseStat = "dexterity";
+		end
+	else
+		nDefense = DB.getValue(nodeDefender, "ac", 10);
+	end
+	nDefenseStatMod = getAbilityBonus(rDefender, sDefenseStat);
+	
+	-- Effects
+	local nAttackEffectMod = 0;
+	local nDefenseEffectMod = 0;
+	local bADV = false;
+	local bDIS = false;
+	if ActorManager.hasCT(rDefender) then
+		local nBonusAC = 0;
+		local nBonusStat = 0;
+		local nBonusSituational = 0;
+		
+		local aAttackFilter = {};
+		if sAttackType == "M" then
+			table.insert(aAttackFilter, "melee");
+		elseif sAttackType == "R" then
+			table.insert(aAttackFilter, "ranged");
+		end
+		if bOpportunity then
+			table.insert(aAttackFilter, "opportunity");
+		end
+
+		local aBonusTargetedAttackDice, nBonusTargetedAttack = EffectManager5E.getEffectsBonus(rAttacker, "ATK", false, aAttackFilter, rDefender, true);
+		nAttackEffectMod = nAttackEffectMod + StringManager.evalDice(aBonusTargetedAttackDice, nBonusTargetedAttack);
+					
+		local aACEffects, nACEffectCount = EffectManager5E.getEffectsBonusByType(rDefender, {"AC"}, true, aAttackFilter, rAttacker);
+		for _,v in pairs(aACEffects) do
+			nBonusAC = nBonusAC + v.mod;
+		end
+		
+		nBonusStat = getAbilityEffectsBonus(rDefender, sDefenseStat);
+		if sDefenderType == "pc" and (nBonusStat > 0) then
+			local sMaxDexBonus = DB.getValue(nodeDefender, "defenses.ac.dexbonus", "");
+			if sMaxDexBonus == "no" then
+				nBonusStat = 0;
+			elseif sMaxDexBonus == "max2" then
+				local nMaxEffectStatModBonus = math.max(2 - nDefenseStatMod, 0);
+				if nBonusStat > nMaxEffectStatModBonus then 
+					nBonusStat = nMaxEffectStatModBonus; 
+				end
+			elseif sMaxDexBonus == "max3" then
+				local nMaxEffectStatModBonus = math.max(3 - nDefenseStatMod, 0);
+				if nBonusStat > nMaxEffectStatModBonus then 
+					nBonusStat = nMaxEffectStatModBonus; 
+				end
+			end
+		end
+		
+		local bProne = false;
+		if EffectManager5E.hasEffect(rAttacker, "ADVATK", rDefender, true) then
+			bADV = true;
+		end
+		if EffectManager5E.hasEffect(rAttacker, "DISATK", rDefender, true) then
+			bDIS = true;
+		end
+		if EffectManager5E.hasEffect(rAttacker, "Invisible", rDefender, true) then
+			bADV = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "GRANTADVATK", rAtracker) then
+			bADV = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "GRANTDISATK", rAtracker) then
+			bDIS = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "Invisible", rAttacker) then
+			bDIS = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "Paralyzed", rAttacker) then
+			bADV = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "Prone", rAttacker) then
+			bProne = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "Restrained", rAttacker) then
+			bADV = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "Stunned", rAttacker) then
+			bADV = true;
+		end
+		if EffectManager5E.hasEffect(rDefender, "Unconscious", rAttacker) then
+			bADV = true;
+			bProne = true;
+		end
+		
+		if bProne then
+			if sAttackType == "M" then
+				bADV = true;
+			elseif sAttackType == "R" then
+				bDIS = true;
+			end
+		end
+		
+		if nCover < 5 then
+			local aCover = EffectManager5E.getEffectsByType(rDefender, "SCOVER", aAttackFilter, rAttacker);
+			if #aCover > 0 or EffectManager5E.hasEffect(rDefender, "SCOVER", rAttacker) then
+				nBonusSituational = nBonusSituational + 5 - nCover;
+			elseif nCover < 2 then
+				aCover = EffectManager5E.getEffectsByType(rDefender, "COVER", aAttackFilter, rAttacker);
+				if #aCover > 0 or EffectManager5E.hasEffect(rDefender, "COVER", rAttacker) then
+					nBonusSituational = nBonusSituational + 2 - nCover;
+				end
+			end
+		end
+		
+		nDefenseEffectMod = nBonusAC + nBonusStat + nBonusSituational;
+	end
+	
+	-- Results
+	return nDefense, nAttackEffectMod, nDefenseEffectMod, bADV, bDIS;
+end
+
+function isAlignment(rActor, sAlignCheck)
+	local nCheckLawChaosAxis = 0;
+	local nCheckGoodEvilAxis = 0;
+	local aCheckSplit = StringManager.split(sAlignCheck:lower(), " ", true);
+	for _,v in ipairs(aCheckSplit) do
+		if nCheckLawChaosAxis == 0 and DataCommon.alignment_lawchaos[v] then
+			nCheckLawChaosAxis = DataCommon.alignment_lawchaos[v];
+		end
+		if nCheckGoodEvilAxis == 0 and DataCommon.alignment_goodevil[v] then
+			nCheckGoodEvilAxis = DataCommon.alignment_goodevil[v];
+		end
+	end
+	if nCheckLawChaosAxis == 0 and nCheckGoodEvilAxis == 0 then
+		return false;
+	end
+	
+	local nActorLawChaosAxis = 2;
+	local nActorGoodEvilAxis = 2;
+	local sType, nodeActor = ActorManager.getTypeAndNode(rActor);
+	local sField = "alignment";
+	local aActorSplit = StringManager.split(DB.getValue(nodeActor, sField, ""):lower(), " ", true);
+	for _,v in ipairs(aActorSplit) do
+		if nActorLawChaosAxis == 2 and DataCommon.alignment_lawchaos[v] then
+			nActorLawChaosAxis = DataCommon.alignment_lawchaos[v];
+		end
+		if nActorGoodEvilAxis == 2 and DataCommon.alignment_goodevil[v] then
+			nActorGoodEvilAxis = DataCommon.alignment_goodevil[v];
+		end
+	end
+	
+	local bLCReturn = true;
+	if nCheckLawChaosAxis > 0 then
+		if nActorLawChaosAxis > 0 then
+			bLCReturn = (nActorLawChaosAxis == nCheckLawChaosAxis);
+		else
+			bLCReturn = false;
+		end
+	end
+	
+	local bGEReturn = true;
+	if nCheckGoodEvilAxis > 0 then
+		if nActorGoodEvilAxis > 0 then
+			bGEReturn = (nActorGoodEvilAxis == nCheckGoodEvilAxis);
+		else
+			bGEReturn = false;
+		end
+	end
+	
+	return (bLCReturn and bGEReturn);
+end
+
+function isSize(rActor, sSizeCheck)
+	local sSizeCheckLower = StringManager.trim(sSizeCheck:lower());
+
+	local sCheckOp = sSizeCheckLower:match("^[<>]?=?");
+	if sCheckOp then
+		sSizeCheckLower = StringManager.trim(sSizeCheckLower:sub(#sCheckOp + 1));
+	end
+	
+	local nCheckSize = 0;
+	if DataCommon.creaturesize[sSizeCheckLower] then
+		nCheckSize = DataCommon.creaturesize[sSizeCheckLower];
+	end
+	if nCheckSize == 0 then
+		return false;
+	end
+	
+	local nActorSize = 0;
+	local sType, nodeActor = ActorManager.getTypeAndNode(rActor);
+	local sField = "size";
+	local aActorSplit = StringManager.split(DB.getValue(nodeActor, sField, ""):lower(), " ", true);
+	for _,v in ipairs(aActorSplit) do
+		if nActorSize == 0 and DataCommon.creaturesize[v] then
+			nActorSize = DataCommon.creaturesize[v];
+			break;
+		end
+	end
+	if nActorSize == 0 then
+		nActorSize = 3;
+	end
+	
+	local bReturn = true;
+	if sCheckOp then
+		if sCheckOp == "<" then
+			bReturn = (nActorSize < nCheckSize);
+		elseif sCheckOp == ">" then
+			bReturn = (nActorSize > nCheckSize);
+		elseif sCheckOp == "<=" then
+			bReturn = (nActorSize <= nCheckSize);
+		elseif sCheckOp == ">=" then
+			bReturn = (nActorSize >= nCheckSize);
+		else
+			bReturn = (nActorSize == nCheckSize);
+		end
+	else
+		bReturn = (nActorSize == nCheckSize);
+	end
+	
+	return bReturn;
+end
+
+function getCreatureTypeHelper(sTypeCheck, bUseDefaultType)
+	local aCheckSplit = StringManager.split(sTypeCheck:lower(), ", %(%)", true);
+	
+	local aTypeCheck = {};
+	local aSubTypeCheck = {};
+	
+	-- Handle half races
+	local nHalfRace = 0;
+	for k = 1, #aCheckSplit do
+		if aCheckSplit[k]:sub(1, #DataCommon.creaturehalftype) == DataCommon.creaturehalftype then
+			aCheckSplit[k] = aCheckSplit[k]:sub(#DataCommon.creaturehalftype + 1);
+			nHalfRace = nHalfRace + 1;
+		end
+	end
+	if nHalfRace == 1 then
+		if not StringManager.contains (aCheckSplit, DataCommon.creaturehalftypesubrace) then
+			table.insert(aCheckSplit, DataCommon.creaturehalftypesubrace);
+		end
+	end
+	
+	-- Check each word combo in the creature type string against standard creature types and subtypes
+	for k = 1, #aCheckSplit do
+		for _,sMainType in ipairs(DataCommon.creaturetype) do
+			local aMainTypeSplit = StringManager.split(sMainType, " ", true);
+			if #aMainTypeSplit > 0 then
+				local bMatch = true;
+				for i = 1, #aMainTypeSplit do
+					if aMainTypeSplit[i] ~= aCheckSplit[k - 1 + i] then
+						bMatch = false;
+						break;
+					end
+				end
+				if bMatch then
+					table.insert(aTypeCheck, sMainType);
+					k = k + (#aMainTypeSplit - 1);
+				end
+			end
+		end
+		for _,sSubType in ipairs(DataCommon.creaturesubtype) do
+			local aSubTypeSplit = StringManager.split(sSubType, " ", true);
+			if #aSubTypeSplit > 0 then
+				local bMatch = true;
+				for i = 1, #aSubTypeSplit do
+					if aSubTypeSplit[i] ~= aCheckSplit[k - 1 + i] then
+						bMatch = false;
+						break;
+					end
+				end
+				if bMatch then
+					table.insert(aSubTypeCheck, sSubType);
+					k = k + (#aSubTypeSplit - 1);
+				end
+			end
+		end
+	end
+	
+	-- Make sure we have a default creature type (if requested)
+	if bUseDefaultType then
+		if #aTypeCheck == 0 then
+			table.insert(aTypeCheck, DataCommon.creaturedefaulttype);
+		end
+	end
+	
+	-- Combine into a single list
+	for _,vSubType in ipairs(aSubTypeCheck) do
+		table.insert(aTypeCheck, vSubType);
+	end
+	
+	return aTypeCheck;
+end
+
+function isCreatureType(rActor, sTypeCheck)
+	local aTypeCheck = getCreatureTypeHelper(sTypeCheck, false);
+	if #aTypeCheck == 0 then
+		return false;
+	end
+	
+	local sType, nodeActor = ActorManager.getTypeAndNode(rActor);
+	local sField = "race";
+	if sType ~= "pc" then
+		sField = "type";
+	end
+	local aTypeActor = getCreatureTypeHelper(DB.getValue(nodeActor, sField, ""), true);
+
+	for _,vCheck in ipairs(aTypeCheck) do
+		if StringManager.contains(aTypeActor, vCheck) then
+			return true;
+		end
+	end
+	return false;
+end

--- a/extensions/ConstitutionalAmendments/source/scripts/manager_effect_5E_CA.lua
+++ b/extensions/ConstitutionalAmendments/source/scripts/manager_effect_5E_CA.lua
@@ -1,0 +1,1089 @@
+-- 
+-- Please see the license.html file included with this distribution for 
+-- attribution and copyright information.
+--
+
+function onInit()
+	EffectManager.registerEffectVar("sUnits", { sDBType = "string", sDBField = "unit", bSkipAdd = true });
+	EffectManager.registerEffectVar("sApply", { sDBType = "string", sDBField = "apply", sDisplay = "[%s]" });
+	EffectManager.registerEffectVar("sTargeting", { sDBType = "string", bClearOnUntargetedDrop = true });
+	
+	EffectManager.setCustomOnEffectAddStart(onEffectAddStart);
+	EffectManager.setCustomOnEffectAddIgnoreCheck(onEffectAddIgnoreCheck);
+	
+	EffectManager.setCustomOnEffectRollEncode(onEffectRollEncode);
+	EffectManager.setCustomOnEffectTextEncode(onEffectTextEncode);
+	EffectManager.setCustomOnEffectTextDecode(onEffectTextDecode);
+
+	EffectManager.setCustomOnEffectActorStartTurn(onEffectActorStartTurn);
+end
+
+--
+-- EFFECT MANAGER OVERRIDES
+--
+
+function onEffectAddStart(rEffect)
+	rEffect.nDuration = rEffect.nDuration or 1;
+	if rEffect.sUnits == "minute" then
+		rEffect.nDuration = rEffect.nDuration * 10;
+	elseif rEffect.sUnits == "hour" or rEffect.sUnits == "day" then
+		rEffect.nDuration = 0;
+	end
+	rEffect.sUnits = "";
+end
+
+function onEffectAddIgnoreCheck(nodeCT, rEffect)
+	-- Check immunities
+	local rSource = ActorManager.getActor("ct", rEffect.sSource);
+	local rTarget = ActorManager.getActor("ct", nodeCT);
+	local sOriginal = rEffect.sName;
+	local aCancelled = checkImmunities(rSource, rTarget, rEffect);
+	if #aCancelled > 0 then
+		if rEffect.sName == "" then
+			return "Effect ['" .. sOriginal .. "'] -> [TARGET IMMUNE]";
+		else
+			local sMsg = "Effect ['" .. sOriginal .. "'] -> [TARGET PARTIALLY IMMUNE] [" .. table.concat(aCancelled, ",") .. "]";
+			EffectManager.message(sMsg, nodeCT, false, sUser);
+		end
+	end
+	return nil;
+end
+
+function onEffectRollEncode(rRoll, rEffect)
+	if rEffect.sTargeting and rEffect.sTargeting == "self" then
+		rRoll.bSelfTarget = true;
+	end
+end
+
+function onEffectTextEncode(rEffect)
+	local aMessage = {};
+	
+	if rEffect.sUnits and rEffect.sUnits ~= "" then
+		local sOutputUnits = nil;
+		if rEffect.sUnits == "minute" then
+			sOutputUnits = "MIN";
+		elseif rEffect.sUnits == "hour" then
+			sOutputUnits = "HR";
+		elseif rEffect.sUnits == "day" then
+			sOutputUnits = "DAY";
+		end
+
+		if sOutputUnits then
+			table.insert(aMessage, "[UNITS " .. sOutputUnits .. "]");
+		end
+	end
+	if rEffect.sTargeting and rEffect.sTargeting ~= "" then
+		table.insert(aMessage, "[" .. rEffect.sTargeting:upper() .. "]");
+	end
+	if rEffect.sApply and rEffect.sApply ~= "" then
+		table.insert(aMessage, "[" .. rEffect.sApply:upper() .. "]");
+	end
+	
+	return table.concat(aMessage, " ");
+end
+
+function onEffectTextDecode(sEffect, rEffect)
+	local s = sEffect;
+	
+	local sUnits = s:match("%[UNITS ([^]]+)]");
+	if sUnits then
+		s = s:gsub("%[UNITS ([^]]+)]", "");
+		if sUnits == "MIN" then
+			rEffect.sUnits = "minute";
+		elseif sUnits == "HR" then
+			rEffect.sUnits = "hour";
+		elseif sUnits == "DAY" then
+			rEffect.sUnits = "day";
+		end
+	end
+	if s:match("%[SELF%]") then
+		s = s:gsub("%[SELF%]", "");
+		rEffect.sTargeting = "self";
+	end
+	if s:match("%[ACTION%]") then
+		s = s:gsub("%[ACTION%]", "");
+		rEffect.sApply = "action";
+	elseif s:match("%[ROLL%]") then
+		s = s:gsub("%[ROLL%]", "");
+		rEffect.sApply = "roll";
+	elseif s:match("%[SINGLE%]") then
+		s = s:gsub("%[SINGLE%]", "");
+		rEffect.sApply = "single";
+	end
+	
+	return s;
+end
+
+function onEffectActorStartTurn(nodeActor, nodeEffect)
+	local sEffName = DB.getValue(nodeEffect, "label", "");
+	local aEffectComps = EffectManager.parseEffect(sEffName);
+	for _,sEffectComp in ipairs(aEffectComps) do
+		local rEffectComp = parseEffectComp(sEffectComp);
+		-- Conditionals
+		if rEffectComp.type == "IFT" then
+			break;
+		elseif rEffectComp.type == "IF" then
+			local rActor = ActorManager.getActorFromCT(nodeActor);
+			if not checkConditional(rActor, nodeEffect, rEffectComp.remainder) then
+				break;
+			end
+		
+		-- Ongoing damage and regeneration
+		elseif rEffectComp.type == "DMGO" or rEffectComp.type == "REGEN" then
+			local nActive = DB.getValue(nodeEffect, "isactive", 0);
+			if nActive == 2 then
+				if rEffectComp.type == "REGEN" and (ActorManager2.getPercentWounded2("ct", nodeActor) >= 1) then 
+					break;
+				end
+				DB.setValue(nodeEffect, "isactive", "number", 1);
+			else
+				applyOngoingDamageAdjustment(nodeActor, nodeEffect, rEffectComp);
+			end
+
+		-- NPC power recharge
+		elseif rEffectComp.type == "RCHG" then
+			local nActive = DB.getValue(nodeEffect, "isactive", 0);
+			if nActive == 2 then
+				DB.setValue(nodeEffect, "isactive", "number", 1);
+			else
+				applyRecharge(nodeActor, nodeEffect, rEffectComp);
+			end
+		end
+	end
+end
+
+--
+-- CUSTOM FUNCTIONS
+--
+
+function parseEffectComp(s)
+	local sType = nil;
+	local aDice = {};
+	local nMod = 0;
+	local aRemainder = {};
+	local nRemainderIndex = 1;
+	
+	local aWords, aWordStats = StringManager.parseWords(s, "%.%[%]%(%):");
+	if #aWords > 0 then
+		sType = aWords[1]:match("^([^:]+):");
+		if sType then
+			nRemainderIndex = 2;
+			
+			local sValueCheck = aWords[1]:sub(#sType + 2);
+			if sValueCheck ~= "" then
+				table.insert(aWords, 2, sValueCheck);
+				table.insert(aWordStats, 2, { startpos = aWordStats[1].startpos + #sType + 1, endpos = aWordStats[1].endpos });
+				aWords[1] = aWords[1]:sub(1, #sType + 1);
+				aWordStats[1].endpos = #sType + 1;
+			end
+			
+			if #aWords > 1 then
+				if StringManager.isDiceString(aWords[2]) then
+					aDice, nMod = StringManager.convertStringToDice(aWords[2]);
+					nRemainderIndex = 3;
+				end
+			end
+		end
+		
+		if nRemainderIndex <= #aWords then
+			while nRemainderIndex <= #aWords and aWords[nRemainderIndex]:match("^%[[%+%-]?%w+%]$") do
+				table.insert(aRemainder, aWords[nRemainderIndex]);
+				nRemainderIndex = nRemainderIndex + 1;
+			end
+		end
+		
+		if nRemainderIndex <= #aWords then
+			local sRemainder = s:sub(aWordStats[nRemainderIndex].startpos);
+			local nStartRemainderPhrase = 1;
+			local i = 1;
+			while i < #sRemainder do
+				local sCheck = sRemainder:sub(i, i);
+				if sCheck == "," then
+					local sRemainderPhrase = sRemainder:sub(nStartRemainderPhrase, i - 1);
+					if sRemainderPhrase and sRemainderPhrase ~= "" then
+						sRemainderPhrase = StringManager.trim(sRemainderPhrase);
+						table.insert(aRemainder, sRemainderPhrase);
+					end
+					nStartRemainderPhrase = i + 1;
+				elseif sCheck == "(" then
+					while i < #sRemainder do
+						if sRemainder:sub(i, i) == ")" then
+							break;
+						end
+						i = i + 1;
+					end
+				elseif sCheck == "[" then
+					while i < #sRemainder do
+						if sRemainder:sub(i, i) == "]" then
+							break;
+						end
+						i = i + 1;
+					end
+				end
+				i = i + 1;
+			end
+			local sRemainderPhrase = sRemainder:sub(nStartRemainderPhrase, #sRemainder);
+			if sRemainderPhrase and sRemainderPhrase ~= "" then
+				sRemainderPhrase = StringManager.trim(sRemainderPhrase);
+				table.insert(aRemainder, sRemainderPhrase);
+			end
+		end
+	end
+
+	return  {
+		type = sType or "", 
+		mod = nMod, 
+		dice = aDice, 
+		remainder = aRemainder, 
+		original = StringManager.trim(s)
+	};
+end
+
+function rebuildParsedEffectComp(rComp)
+	if not rComp then
+		return "";
+	end
+	
+	local aComp = {};
+	if rComp.type ~= "" then
+		table.insert(aComp, rComp.type .. ":");
+	end
+	local sDiceString = StringManager.convertDiceToString(rComp.dice, rComp.mod);
+	if sDiceString ~= "" then
+		table.insert(aComp, sDiceString);
+	end
+	if #(rComp.remainder) > 0 then
+		table.insert(aComp, table.concat(rComp.remainder, ","));
+	end
+	return table.concat(aComp, " ");
+end
+
+function removeEffectByType(nodeCT, sEffectType)
+	if not sEffectType then
+		return;
+	end
+	local aEffectsToDelete = {};
+
+	for _,nodeEffect in pairs(DB.getChildren(nodeCT, "effects")) do
+		local nActive = DB.getValue(nodeEffect, "isactive", 0);
+		if (nActive ~= 0) then
+			local s = DB.getValue(nodeEffect, "label", "");
+			
+			local aCompsToDelete = {};
+			
+			local aEffectComps = EffectManager.parseEffect(s);
+			local nComp = 1;
+			for _,sEffectComp in ipairs(aEffectComps) do
+				local rEffectComp = parseEffectComp(sEffectComp);
+				-- Check conditionals
+				if rEffectComp.type == "IFT" then
+					break;
+				elseif rEffectComp.type == "IF" then
+					local rActor = ActorManager.getActorFromCT(nodeActor);
+					if not checkConditional(rActor, nodeEffect, rEffectComp.remainder) then
+						break;
+					end
+				
+				-- Check for effect match
+				elseif rEffectComp.type == sEffectType then
+					table.insert(aCompsToDelete, nComp);
+				end
+				
+				nComp = nComp + 1;
+			end
+			
+			-- Delete portion of effect that matches (or register for full deletion)
+			if #aCompsToDelete >= #aEffectComps then
+				table.insert(aEffectsToDelete, nodeEffect);
+			elseif #aCompsToDelete > 0 then
+				local aNewEffectComps = {};
+				local nEffectComps = #aEffectComps;
+				for i = 1,nEffectComps do
+					if not StringManager.contains(aCompsToDelete, i) then
+						table.insert(aNewEffectComps, aEffectComps[i]);
+					end
+				end
+				
+				local sNewEffect = EffectManager.rebuildParsedEffect(aNewEffectComps);
+				DB.setValue(nodeEffect, "label", "string", sNewEffect);
+			end
+		end
+	end
+	
+	for _,v in ipairs(aEffectsToDelete) do
+		v.delete();
+	end
+end
+
+function checkImmunities(rSource, rTarget, rEffect)
+	local aImmune = getEffectsByType(rTarget, "IMMUNE", {}, rSource);
+	
+	local aImmuneConditions = {};
+	for _,v in pairs(aImmune) do
+		for _,vType in pairs(v.remainder) do
+			if vType ~= "" and vType:sub(1,1) ~= "!" and vType:sub(1,1) ~= "~" then
+				if StringManager.contains(DataCommon.conditions, vType) then
+					table.insert(aImmuneConditions, vType:lower());
+				end
+			end
+		end
+	end
+	if #aImmuneConditions == 0 then
+		return {};
+	end
+	
+	local aNewEffectComps = {};
+	local aCancelled = {};
+	
+	local aEffectComps = EffectManager.parseEffect(rEffect.sName);
+	for _,sEffectComp in ipairs(aEffectComps) do
+		local rEffectComp = parseEffectComp(sEffectComp);
+		if StringManager.contains(aImmuneConditions, rEffectComp.original:lower()) then
+			table.insert(aCancelled, rEffectComp.original);
+		else
+			table.insert(aNewEffectComps, sEffectComp);
+		end
+	end
+	if #aCancelled == 0 then
+		return {};
+	end
+	
+	rEffect.sName = EffectManager.rebuildParsedEffect(aNewEffectComps);
+	if rEffect.sName == "(C)" then
+		rEffect.sName = "";
+	end
+	return aCancelled;
+end
+
+function applyOngoingDamageAdjustment(nodeActor, nodeEffect, rEffectComp)
+	if #(rEffectComp.dice) == 0 and rEffectComp.mod == 0 then
+		return;
+	end
+	
+	local rTarget = ActorManager.getActor("ct", nodeActor);
+	if rEffectComp.type == "REGEN" then
+		local nPercentWounded = ActorManager2.getPercentWounded2("ct", nodeActor);
+		
+		-- If not wounded, then return
+		if nPercentWounded <= 0 then
+			return;
+		end
+		-- Regeneration does not work once creature falls below 1 hit point (but only if no specific damage type needed to disable regeneration)
+		if nPercentWounded >= 1 and (#(rEffectComp.remainder) == 0) then
+			return;
+		end
+		
+		local rAction = {};
+		rAction.label = "Regeneration";
+		rAction.clauses = {};
+		
+		local aClause = {};
+		aClause.dice = rEffectComp.dice;
+		aClause.modifier = rEffectComp.mod;
+		table.insert(rAction.clauses, aClause);
+		
+		local rRoll = ActionHeal.getRoll(nil, rAction);
+		if EffectManager.isGMEffect(nodeActor, nodeEffect) then
+			rRoll.bSecret = true;
+		end
+		ActionsManager.actionDirect(nil, "heal", { rRoll }, { { rTarget } });
+	else
+		local rAction = {};
+		rAction.label = "Ongoing damage";
+		rAction.clauses = {};
+		
+		local aClause = {};
+		aClause.dice = rEffectComp.dice;
+		aClause.modifier = rEffectComp.mod;
+		aClause.dmgtype = string.lower(table.concat(rEffectComp.remainder, ","));
+		table.insert(rAction.clauses, aClause);
+		
+		local rRoll = ActionDamage.getRoll(nil, rAction);
+		if EffectManager.isGMEffect(nodeActor, nodeEffect) then
+			rRoll.bSecret = true;
+		end
+		ActionsManager.actionDirect(nil, "damage", { rRoll }, { { rTarget } });
+	end
+end
+
+function applyRecharge(nodeActor, nodeEffect, rEffectComp)
+	local rActor = ActorManager.getActorFromCT(nodeActor);
+	local sRecharge = table.concat(rEffectComp.remainder, " ");
+	ActionRecharge.performRoll(nil, rActor, sRecharge, rEffectComp.mod, EffectManager.isGMEffect(nodeActor, nodeEffect), nodeEffect);
+end
+
+function evalAbilityHelper(rActor, sEffectAbility)
+	local sSign, sModifier, sTag = sEffectAbility:match("^%[([%+%-]?)([H%d]?)([A-Z]+)%]$");
+	
+	local nAbility = nil;
+	if sTag == "STR" then
+		nAbility = ActorManager2.getAbilityBonus(rActor, "strength");
+	elseif sTag == "DEX" then
+		nAbility = ActorManager2.getAbilityBonus(rActor, "dexterity");
+	elseif sTag == "CON" then
+		nAbility = ActorManager2.getAbilityBonus(rActor, "constitution");
+	elseif sTag == "INT" then
+		nAbility = ActorManager2.getAbilityBonus(rActor, "intelligence");
+	elseif sTag == "WIS" then
+		nAbility = ActorManager2.getAbilityBonus(rActor, "wisdom");
+	elseif sTag == "CHA" then
+		nAbility = ActorManager2.getAbilityBonus(rActor, "charisma");
+	elseif sTag == "LVL" then
+		nAbility = ActorManager2.getAbilityBonus(rActor, "level");
+	elseif sTag == "PRF" then
+		nAbility = ActorManager2.getAbilityBonus(rActor, "prf");
+	else
+		nAbility = ActorManager2.getAbilityScore(rActor, sTag:lower());
+	end
+	
+	if nAbility then
+		if sSign == "-" then
+			nAbility = 0 - nAbility;
+		end
+		if sModifier == "H" then
+			if nAbility > 0 then
+				nAbility = math.floor(nAbility / 2);
+			else
+				nAbility = math.ceil(nAbility / 2);
+			end
+		elseif sModifier then
+			nAbility = nAbility * (tonumber(sModifier) or 1);
+		end
+	end
+	
+	return nAbility;
+end
+
+function evalEffect(rActor, s)
+	if not s then
+		return "";
+	end
+	if not rActor then
+		return s;
+	end
+	
+	local aNewEffectComps = {};
+	local aEffectComps = EffectManager.parseEffect(s);
+	for _,sEffectComp in ipairs(aEffectComps) do
+		local vComp = parseEffectComp(sEffectComp);
+		for i = #(vComp.remainder), 1, -1 do
+			if vComp.remainder[i]:match("^%[([%+%-]?)([H%d]?)([A-Z]+)%]$") then
+				local nAbility = evalAbilityHelper(rActor, vComp.remainder[i]);
+				if nAbility then
+					vComp.mod = vComp.mod + nAbility;
+					table.remove(vComp.remainder, i);
+				end
+			end
+		end
+		table.insert(aNewEffectComps, rebuildParsedEffectComp(vComp));
+	end
+	local sOutput = EffectManager.rebuildParsedEffect(aNewEffectComps);
+
+	return sOutput;
+end
+
+function getEffectsByType(rActor, sEffectType, aFilter, rFilterActor, bTargetedOnly)
+	if not rActor then
+		return {};
+	end
+	local results = {};
+	
+	-- Set up filters
+	local aRangeFilter = {};
+	local aOtherFilter = {};
+	if aFilter then
+		for _,v in pairs(aFilter) do
+			if type(v) ~= "string" then
+				table.insert(aOtherFilter, v);
+			elseif StringManager.contains(DataCommon.rangetypes, v) then
+				table.insert(aRangeFilter, v);
+			else
+				table.insert(aOtherFilter, v);
+			end
+		end
+	end
+	
+	-- Iterate through effects
+	for _,v in pairs(DB.getChildren(ActorManager.getCTNode(rActor), "effects")) do
+		-- Check active
+		local nActive = DB.getValue(v, "isactive", 0);
+		if (nActive ~= 0) then
+			local sLabel = DB.getValue(v, "label", "");
+			local sApply = DB.getValue(v, "apply", "");
+
+			-- IF COMPONENT WE ARE LOOKING FOR SUPPORTS TARGETS, THEN CHECK AGAINST OUR TARGET
+			local bTargeted = EffectManager.isTargetedEffect(v);
+			if not bTargeted or EffectManager.isEffectTarget(v, rFilterActor) then
+				local aEffectComps = EffectManager.parseEffect(sLabel);
+
+				-- Look for type/subtype match
+				local nMatch = 0;
+				for kEffectComp,sEffectComp in ipairs(aEffectComps) do
+					local rEffectComp = parseEffectComp(sEffectComp);
+					-- Handle conditionals
+					if rEffectComp.type == "IF" then
+						if not checkConditional(rActor, v, rEffectComp.remainder) then
+							break;
+						end
+					elseif rEffectComp.type == "IFT" then
+						if not rFilterActor then
+							break;
+						end
+						if not checkConditional(rFilterActor, v, rEffectComp.remainder, rActor) then
+							break;
+						end
+						bTargeted = true;
+					
+					-- Compare other attributes
+					else
+						-- Strip energy/bonus types for subtype comparison
+						local aEffectRangeFilter = {};
+						local aEffectOtherFilter = {};
+						local j = 1;
+						while rEffectComp.remainder[j] do
+							local s = rEffectComp.remainder[j];
+							if #s > 0 and ((s:sub(1,1) == "!") or (s:sub(1,1) == "~")) then
+								s = s:sub(2);
+							end
+							if StringManager.contains(DataCommon.dmgtypes, s) or s == "all" or 
+									StringManager.contains(DataCommon.bonustypes, s) or
+									StringManager.contains(DataCommon.conditions, s) or
+									StringManager.contains(DataCommon.connectors, s) then
+								-- SKIP
+							elseif StringManager.contains(DataCommon.rangetypes, s) then
+								table.insert(aEffectRangeFilter, s);
+							else
+								table.insert(aEffectOtherFilter, s);
+							end
+							
+							j = j + 1;
+						end
+					
+						-- Check for match
+						local comp_match = false;
+						if rEffectComp.type == sEffectType then
+
+							-- Check effect targeting
+							if bTargetedOnly and not bTargeted then
+								comp_match = false;
+							else
+								comp_match = true;
+							end
+						
+							-- Check filters
+							if #aEffectRangeFilter > 0 then
+								local bRangeMatch = false;
+								for _,v2 in pairs(aRangeFilter) do
+									if StringManager.contains(aEffectRangeFilter, v2) then
+										bRangeMatch = true;
+										break;
+									end
+								end
+								if not bRangeMatch then
+									comp_match = false;
+								end
+							end
+							if #aEffectOtherFilter > 0 then
+								local bOtherMatch = false;
+								for _,v2 in pairs(aOtherFilter) do
+									if type(v2) == "table" then
+										local bOtherTableMatch = true;
+										for k3, v3 in pairs(v2) do
+											if not StringManager.contains(aEffectOtherFilter, v3) then
+												bOtherTableMatch = false;
+												break;
+											end
+										end
+										if bOtherTableMatch then
+											bOtherMatch = true;
+											break;
+										end
+									elseif StringManager.contains(aEffectOtherFilter, v2) then
+										bOtherMatch = true;
+										break;
+									end
+								end
+								if not bOtherMatch then
+									comp_match = false;
+								end
+							end
+						end
+
+						-- Match!
+						if comp_match then
+							nMatch = kEffectComp;
+							if nActive == 1 then
+								table.insert(results, rEffectComp);
+							end
+						end
+					end
+				end -- END EFFECT COMPONENT LOOP
+
+				-- -- Remove one shot effects -- this is bad for 'passive' use of effects
+				-- if nMatch > 0 then
+					-- if nActive == 2 then
+						-- DB.setValue(v, "isactive", "number", 1);
+					-- else
+						-- if sApply == "action" then
+							-- EffectManager.notifyExpire(v, 0);
+						-- elseif sApply == "roll" then
+							-- EffectManager.notifyExpire(v, 0, true);
+						-- elseif sApply == "single" then
+							-- EffectManager.notifyExpire(v, nMatch, true);
+						-- end
+					-- end
+				-- end
+			end -- END TARGET CHECK
+		end  -- END ACTIVE CHECK
+	end  -- END EFFECT LOOP
+	
+	-- RESULTS
+	return results;
+end
+
+function getEffectsBonusByType(rActor, aEffectType, bAddEmptyBonus, aFilter, rFilterActor, bTargetedOnly)
+	if not rActor or not aEffectType then
+		return {}, 0;
+	end
+	
+	-- MAKE BONUS TYPE INTO TABLE, IF NEEDED
+	if type(aEffectType) ~= "table" then
+		aEffectType = { aEffectType };
+	end
+	
+	-- PER EFFECT TYPE VARIABLES
+	local results = {};
+	local bonuses = {};
+	local penalties = {};
+	local nEffectCount = 0;
+	
+	for k, v in pairs(aEffectType) do
+		-- LOOK FOR EFFECTS THAT MATCH BONUSTYPE
+		local aEffectsByType = getEffectsByType(rActor, v, aFilter, rFilterActor, bTargetedOnly);
+
+		-- ITERATE THROUGH EFFECTS THAT MATCHED
+		for k2,v2 in pairs(aEffectsByType) do
+			-- LOOK FOR ENERGY OR BONUS TYPES
+			local dmg_type = nil;
+			local mod_type = nil;
+			for _,v3 in pairs(v2.remainder) do
+				if StringManager.contains(DataCommon.dmgtypes, v3) or StringManager.contains(DataCommon.conditions, v3) or v3 == "all" then
+					dmg_type = v3;
+					break;
+				elseif StringManager.contains(DataCommon.bonustypes, v3) then
+					mod_type = v3;
+					break;
+				end
+			end
+			
+			-- IF MODIFIER TYPE IS UNTYPED, THEN APPEND MODIFIERS
+			-- (SUPPORTS DICE)
+			if dmg_type or not mod_type then
+				-- ADD EFFECT RESULTS 
+				local new_key = dmg_type or "";
+				local new_results = results[new_key] or {dice = {}, mod = 0, remainder = {}};
+
+				-- BUILD THE NEW RESULT
+				for _,v3 in pairs(v2.dice) do
+					table.insert(new_results.dice, v3); 
+				end
+				if bAddEmptyBonus then
+					new_results.mod = new_results.mod + v2.mod;
+				else
+					new_results.mod = math.max(new_results.mod, v2.mod);
+				end
+				for _,v3 in pairs(v2.remainder) do
+					table.insert(new_results.remainder, v3);
+				end
+
+				-- SET THE NEW DICE RESULTS BASED ON ENERGY TYPE
+				results[new_key] = new_results;
+
+			-- OTHERWISE, TRACK BONUSES AND PENALTIES BY MODIFIER TYPE 
+			-- (IGNORE DICE, ONLY TAKE BIGGEST BONUS AND/OR PENALTY FOR EACH MODIFIER TYPE)
+			else
+				local bStackable = StringManager.contains(DataCommon.stackablebonustypes, mod_type);
+				if v2.mod >= 0 then
+					if bStackable then
+						bonuses[mod_type] = (bonuses[mod_type] or 0) + v2.mod;
+					else
+						bonuses[mod_type] = math.max(v2.mod, bonuses[mod_type] or 0);
+					end
+				elseif v2.mod < 0 then
+					if bStackable then
+						penalties[mod_type] = (penalties[mod_type] or 0) + v2.mod;
+					else
+						penalties[mod_type] = math.min(v2.mod, penalties[mod_type] or 0);
+					end
+				end
+
+			end
+			
+			-- INCREMENT EFFECT COUNT
+			nEffectCount = nEffectCount + 1;
+		end
+	end
+
+	-- COMBINE BONUSES AND PENALTIES FOR NON-ENERGY TYPED MODIFIERS
+	for k2,v2 in pairs(bonuses) do
+		if results[k2] then
+			results[k2].mod = results[k2].mod + v2;
+		else
+			results[k2] = {dice = {}, mod = v2, remainder = {}};
+		end
+	end
+	for k2,v2 in pairs(penalties) do
+		if results[k2] then
+			results[k2].mod = results[k2].mod + v2;
+		else
+			results[k2] = {dice = {}, mod = v2, remainder = {}};
+		end
+	end
+
+	return results, nEffectCount;
+end
+
+function getEffectsBonus(rActor, aEffectType, bModOnly, aFilter, rFilterActor, bTargetedOnly)
+	if not rActor or not aEffectType then
+		if bModOnly then
+			return 0, 0;
+		end
+		return {}, 0, 0;
+	end
+	
+	-- MAKE BONUS TYPE INTO TABLE, IF NEEDED
+	if type(aEffectType) ~= "table" then
+		aEffectType = { aEffectType };
+	end
+	
+	-- START WITH AN EMPTY MODIFIER TOTAL
+	local aTotalDice = {};
+	local nTotalMod = 0;
+	local nEffectCount = 0;
+	
+	-- ITERATE THROUGH EACH BONUS TYPE
+	local masterbonuses = {};
+	local masterpenalties = {};
+	for k, v in pairs(aEffectType) do
+		-- GET THE MODIFIERS FOR THIS MODIFIER TYPE
+		local effbonusbytype, nEffectSubCount = getEffectsBonusByType(rActor, v, true, aFilter, rFilterActor, bTargetedOnly);
+		
+		-- ITERATE THROUGH THE MODIFIERS
+		for k2, v2 in pairs(effbonusbytype) do
+			-- IF MODIFIER TYPE IS UNTYPED, THEN APPEND TO TOTAL MODIFIER
+			-- (SUPPORTS DICE)
+			if k2 == "" or StringManager.contains(DataCommon.dmgtypes, k2) then
+				for k3, v3 in pairs(v2.dice) do
+					table.insert(aTotalDice, v3);
+				end
+				nTotalMod = nTotalMod + v2.mod;
+			
+			-- OTHERWISE, WE HAVE A NON-ENERGY MODIFIER TYPE, WHICH MEANS WE NEED TO INTEGRATE
+			-- (IGNORE DICE, ONLY TAKE BIGGEST BONUS AND/OR PENALTY FOR EACH MODIFIER TYPE)
+			else
+				if v2.mod >= 0 then
+					masterbonuses[k2] = math.max(v2.mod, masterbonuses[k2] or 0);
+				elseif v2.mod < 0 then
+					masterpenalties[k2] = math.min(v2.mod, masterpenalties[k2] or 0);
+				end
+			end
+		end
+
+		-- ADD TO EFFECT COUNT
+		nEffectCount = nEffectCount + nEffectSubCount;
+	end
+
+	-- ADD INTEGRATED BONUSES AND PENALTIES FOR NON-ENERGY TYPED MODIFIERS
+	for k,v in pairs(masterbonuses) do
+		nTotalMod = nTotalMod + v;
+	end
+	for k,v in pairs(masterpenalties) do
+		nTotalMod = nTotalMod + v;
+	end
+	
+	if bModOnly then
+		return nTotalMod, nEffectCount;
+	end
+	return aTotalDice, nTotalMod, nEffectCount;
+end
+
+function hasEffectCondition(rActor, sEffect)
+	return hasEffect(rActor, sEffect, nil, false, true);
+end
+
+function hasEffect(rActor, sEffect, rTarget, bTargetedOnly, bIgnoreEffectTargets)
+	if not sEffect or not rActor then
+		return false;
+	end
+	local sLowerEffect = sEffect:lower();
+	
+	-- Iterate through each effect
+	local aMatch = {};
+	for _,v in pairs(DB.getChildren(ActorManager.getCTNode(rActor), "effects")) do
+		local nActive = DB.getValue(v, "isactive", 0);
+		if nActive ~= 0 then
+			-- Parse each effect label
+			local sLabel = DB.getValue(v, "label", "");
+			local bTargeted = EffectManager.isTargetedEffect(v);
+			local aEffectComps = EffectManager.parseEffect(sLabel);
+
+			-- Iterate through each effect component looking for a type match
+			local nMatch = 0;
+			for kEffectComp,sEffectComp in ipairs(aEffectComps) do
+				local rEffectComp = parseEffectComp(sEffectComp);
+				-- Handle conditionals
+				if rEffectComp.type == "IF" then
+					if not checkConditional(rActor, v, rEffectComp.remainder) then
+						break;
+					end
+				elseif rEffectComp.type == "IFT" then
+					if not rTarget then
+						break;
+					end
+					if not checkConditional(rTarget, v, rEffectComp.remainder, rActor) then
+						break;
+					end
+				
+				-- Check for match
+				elseif rEffectComp.original:lower() == sLowerEffect then
+					if bTargeted and not bIgnoreEffectTargets then
+						if EffectManager.isEffectTarget(v, rTarget) then
+							nMatch = kEffectComp;
+						end
+					elseif not bTargetedOnly then
+						nMatch = kEffectComp;
+					end
+				end
+				
+			end
+			
+			-- If matched, then remove one-off effects
+			if nMatch > 0 then
+				if nActive == 2 then
+					-- DB.setValue(v, "isactive", "number", 1); -- this is bad for 'passive' use of effects
+				else
+					table.insert(aMatch, v);
+					local sApply = DB.getValue(v, "apply", "");
+					if sApply == "action" then
+						EffectManager.notifyExpire(v, 0);
+					elseif sApply == "roll" then
+						EffectManager.notifyExpire(v, 0, true);
+					elseif sApply == "single" then
+						EffectManager.notifyExpire(v, nMatch, true);
+					end
+				end
+			end
+		end
+	end
+	
+	if #aMatch > 0 then
+		return true;
+	end
+	return false;
+end
+
+function checkConditional(rActor, nodeEffect, aConditions, rTarget, aIgnore)
+	local bReturn = true;
+	
+	if not aIgnore then
+		aIgnore = {};
+	end
+	table.insert(aIgnore, nodeEffect.getNodeName());
+	
+	for _,v in ipairs(aConditions) do
+		local sLower = v:lower();
+		if sLower == DataCommon.healthstatusfull then
+			local nPercentWounded = ActorManager2.getPercentWounded(rActor);
+			if nPercentWounded > 0 then
+				bReturn = false;
+				break;
+			end
+		elseif sLower == DataCommon.healthstatushalf then
+			local nPercentWounded = ActorManager2.getPercentWounded(rActor);
+			if nPercentWounded < .5 then
+				bReturn = false;
+				break;
+			end
+		elseif sLower == DataCommon.healthstatuswounded then
+			local nPercentWounded = ActorManager2.getPercentWounded(rActor);
+			if nPercentWounded == 0 then
+				bReturn = false;
+				break;
+			end
+		elseif StringManager.contains(DataCommon.conditions, sLower) then
+			if not checkConditionalHelper(rActor, sLower, rTarget, aIgnore) then
+				bReturn = false;
+				break;
+			end
+		elseif StringManager.contains(DataCommon.conditionaltags, sLower) then
+			if not checkConditionalHelper(rActor, sLower, rTarget, aIgnore) then
+				bReturn = false;
+				break;
+			end
+		else
+			local sAlignCheck = sLower:match("^align%s*%(([^)]+)%)$");
+			local sSizeCheck = sLower:match("^size%s*%(([^)]+)%)$");
+			local sTypeCheck = sLower:match("^type%s*%(([^)]+)%)$");
+			local sCustomCheck = sLower:match("^custom%s*%(([^)]+)%)$");
+			if sAlignCheck then
+				if not ActorManager2.isAlignment(rActor, sAlignCheck) then
+					bReturn = false;
+					break;
+				end
+			elseif sSizeCheck then
+				if not ActorManager2.isSize(rActor, sSizeCheck) then
+					bReturn = false;
+					break;
+				end
+			elseif sTypeCheck then
+				if not ActorManager2.isCreatureType(rActor, sTypeCheck) then
+					bReturn = false;
+					break;
+				end
+			elseif sCustomCheck then
+				if not checkConditionalHelper(rActor, sCustomCheck, rTarget, aIgnore) then
+					bReturn = false;
+					break;
+				end
+			end
+		end
+	end
+	
+	table.remove(aIgnore);
+	
+	return bReturn;
+end
+
+function checkConditionalHelper(rActor, sEffect, rTarget, aIgnore)
+	if not rActor then
+		return false;
+	end
+	
+	for _,v in pairs(DB.getChildren(ActorManager.getCTNode(rActor), "effects")) do
+		local nActive = DB.getValue(v, "isactive", 0);
+		if nActive ~= 0 and not StringManager.contains(aIgnore, v.getNodeName()) then
+			-- Parse each effect label
+			local sLabel = DB.getValue(v, "label", "");
+			local aEffectComps = EffectManager.parseEffect(sLabel);
+
+			-- Iterate through each effect component looking for a type match
+			for _,sEffectComp in ipairs(aEffectComps) do
+				local rEffectComp = parseEffectComp(sEffectComp);
+				
+				-- CHECK CONDITIONALS
+				if rEffectComp.type == "IF" then
+					if not checkConditional(rActor, v, rEffectComp.remainder, nil, aIgnore) then
+						break;
+					end
+				elseif rEffectComp.type == "IFT" then
+					if not rTarget then
+						break;
+					end
+					if not checkConditional(rTarget, v, rEffectComp.remainder, rActor, aIgnore) then
+						break;
+					end
+				
+				-- CHECK FOR AN ACTUAL EFFECT MATCH
+				elseif rEffectComp.original:lower() == sEffect then
+					if EffectManager.isTargetedEffect(v) then
+						if EffectManager.isEffectTarget(v, rTarget) then
+							return true;
+						end
+					else
+						return true;
+					end
+				end
+			end
+		end
+	end
+	
+	return false;
+end
+
+function encodeEffectForCT(rEffect)
+	local aMessage = {};
+	
+	if rEffect then
+		table.insert(aMessage, "EFF:");
+		table.insert(aMessage, rEffect.sName);
+
+		local sDurDice = StringManager.convertDiceToString(rEffect.aDice, rEffect.nDuration);
+		if sDurDice ~= "" then
+			local sOutputUnits = nil;
+			if rEffect.sUnits and rEffect.sUnits ~= "" then
+				if rEffect.sUnits == "minute" then
+					sOutputUnits = "MIN";
+				elseif rEffect.sUnits == "hour" then
+					sOutputUnits = "HR";
+				elseif rEffect.sUnits == "day" then
+					sOutputUnits = "DAY";
+				end
+			end
+			
+			if sOutputUnits then
+				table.insert(aMessage, "(D:" .. sDurDice .. " " .. sOutputUnits .. ")");
+			else
+				table.insert(aMessage, "(D:" .. sDurDice .. ")");
+			end
+		end
+
+		if rEffect.sTargeting and rEffect.sTargeting ~= "" then
+			table.insert(aMessage, "(T:" .. rEffect.sTargeting:upper() .. ")");
+		end
+		
+		if rEffect.sApply and rEffect.sApply ~= "" then
+			table.insert(aMessage, "(A:" .. rEffect.sApply:upper() .. ")");
+		end
+	end
+	
+	return "[" .. table.concat(aMessage, " ") .. "]";
+end
+
+function decodeEffectFromCT(sEffect)
+	local rEffect = nil;
+
+	local sEffectName = sEffect:match("EFF: ?(.+)");
+	if sEffectName then
+		rEffect = {};
+		
+		rEffect.sType = "effect";
+		
+		rEffect.nDuration = 0;
+		rEffect.sUnits = "";
+		local sDurDice, sUnits = sEffect:match("%(D:([d%dF%+%-]+) ?([^)]*)%)");
+		if sDurDice then
+			rEffect.aDice, rEffect.nDuration = StringManager.convertStringToDice(sDurDice);
+			if sUnits then
+				if sUnits == "MIN" then
+					rEffect.sUnits = "minute";
+				elseif sUnits == "HR" then
+					rEffect.sUnits = "hour";
+				elseif sUnits == "DAY" then
+					rEffect.sUnits = "day";
+				end
+			end
+		end
+		sEffectName = sEffectName:gsub("%(D:[^)]*%)", "");
+		
+		rEffect.sTargeting = "";
+		if sEffect:match("%(T:SELF%)") then
+			rEffect.sTargeting = "self";
+		end
+		sEffectName = sEffectName:gsub("%(T:[^)]*%)", "");
+		
+		rEffect.sApply = "";
+		if sEffect:match("%(A:ACTION%)") then
+			rEffect.sApply = "action";
+		elseif sEffect:match("%(A:ROLL%)") then
+			rEffect.sApply = "roll";
+		elseif sEffect:match("%(A:SINGLE%)") then
+			rEffect.sApply = "single";
+		end
+		sEffectName = sEffectName:gsub("%(A:[^)]*%)", "");
+
+		rEffect.sName = StringManager.trim(sEffectName);
+	end
+	
+	return rEffect;
+end
+

--- a/extensions/ConstitutionalAmendments/source/scripts/manager_hp.lua
+++ b/extensions/ConstitutionalAmendments/source/scripts/manager_hp.lua
@@ -283,7 +283,7 @@ end
 
 -- Utility
 function getConAdjustment(nodeChar)
-	local nMod, _ = ActorManager2.getAbilityEffectsBonus(nodeChar, "constitution")
+	local nMod, _ = ActorManager2CA.getAbilityEffectsBonus(nodeChar, "constitution")
 	local nLevels = getTotalLevel(nodeChar);
 	return nMod * nLevels;
 end


### PR DESCRIPTION
Parsing effects for a bonus will set them to active if they were set to skip.
Because you were triggering off of them being set to skip, it was turning them back on immediately.

Now, if you need to get effect bonuses in a passive manner (not re-enabling skipped effects) you can just call those functions from EffectsManager5ECA and ActorManager2CA instead of the original versions.

I have not tested this, but it is very similar to what I have done to make my effect extensions work in 3.5E.
If it doesn't totally fix it for you, it should get you very close.